### PR TITLE
위젯 api

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,6 @@ import {
 } from './pages';
 
 function App() {
-  const userUrl = 'juepark';
   return (
     <Router>
       <Switch>
@@ -28,7 +27,6 @@ function App() {
           component={RenewAccessToken}
         />
         <Route exact path='/:id/' component={NormalModePage} />
-        <Route exact path={userUrl} component={NormalModePage} />
         <Route exact path='/:id/edit' component={EditModePage} />
         <Route exact path='/:id/save' component={SavePage} />
         <Route path='/'>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,13 +1,14 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
 import { css } from '@emotion/react';
+import { useHistory } from 'react-router';
 import { HeaderWrapper } from '..';
 import { logo, mypage, search } from '../../asset';
 import { logout } from '../../utils/router';
 
-function Header({ userMatch, pageUserId, pageUserName, pageType }) {
+function Header({ userMatch, pageUrl, pageUserName, pageType }) {
+  const history = useHistory();
   if (pageType === 'main') {
-    const user_seq = localStorage.getItem('user_seq');
     return (
       <HeaderWrapper>
         <div css={[flex, flexBtw]}>
@@ -26,7 +27,7 @@ function Header({ userMatch, pageUserId, pageUserName, pageType }) {
 
             <a
               href='#'
-              onClick={() => window.location.assign(`/${user_seq}`)}
+              onClick={() => history.push(`/${pageUrl}`)}
               css={marginRight17}
             >
               <img alt='img' src={mypage} css={height26} />
@@ -41,8 +42,7 @@ function Header({ userMatch, pageUserId, pageUserName, pageType }) {
         </div>
       </HeaderWrapper>
     );
-  } else {
-    const user_seq = localStorage.getItem('user_seq');
+  } else if (pageType === 'normal') {
     return (
       <HeaderWrapper>
         <div css={[flex, flexBtw]}>
@@ -62,7 +62,7 @@ function Header({ userMatch, pageUserId, pageUserName, pageType }) {
                 <button
                   type='button'
                   css={[commonButtonStyle, confirmButtonWidth, marginRight17]}
-                  onClick={() => window.location.assign(`/${pageUserId}/edit`)}
+                  onClick={() => history.push(`/${pageUrl}/edit`)}
                 >
                   페이지 수정
                 </button>
@@ -71,7 +71,7 @@ function Header({ userMatch, pageUserId, pageUserName, pageType }) {
             {!userMatch && (
               <a
                 href='#'
-                onClick={() => window.location.assign(`/${user_seq}`)}
+                onClick={() => history.push(`/${pageUrl}`)}
                 css={marginRight17}
               >
                 <img alt='img' src={mypage} css={height26} />

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -10,6 +10,7 @@ import { COLOR_STYLE, InitButtonStyle } from '../styles/GlobalStyles';
 import { useRequestAuth } from '../hooks/useRequestAuth';
 // import useSaveUserInfo from '../hooks/useSaveUserInfo';
 
+// TODO: 4차 업데이트로 보류 => github issue에 올리기
 function Login() {
   const [showPassword, setShowPassword] = useState(false);
 
@@ -44,13 +45,6 @@ function Login() {
     method: 'get',
   });
 
-  // const { res: savedUserInfo, request: saveUserInfoToRedux } = useSaveUserInfo({
-  //   url: 'normal',
-  //   nickname: '주은',
-  //   userSeq: 73,
-  //   field: ['painting'],
-  // });
-
   const handleKakaoLogin = () => {
     const endpoint = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.REACT_APP_KAKAO_CLIENT_SECRET}&redirect_uri=${process.env.REACT_APP_KAKAO_REDIRECT_URI}&response_type=code`;
     window.location.assign(endpoint);
@@ -58,8 +52,16 @@ function Login() {
   const history = useHistory();
 
   const handleLocalLogin = () => {
-    console.log('로그인 요청');
-    request();
+    // TODO: state 검사 해야됨('ok' 일때만 요청 하도록)
+    if (email.state !== 'ok' && password.state !== 'ok') {
+      alert('아이디와 비밀번호를 입력해주세요.');
+    } else if (email.state !== 'ok') {
+      alert('아이디를 입력해주세요.');
+    } else if (password.state !== 'ok') {
+      alert('비밀번호를 입력해주세요.');
+    } else {
+      request();
+    }
   };
 
   useEffect(() => {
@@ -72,6 +74,7 @@ function Login() {
       } else if (res.data.code === 'unauthorized') {
         alert('존재하지 않는 아이디입니다.');
       } else if (res.data.code === 'ok') {
+        console.log(res.data.data);
         setLocalStorage(res.data.data);
         userInfoRequest();
       }
@@ -80,6 +83,7 @@ function Login() {
 
   useEffect(() => {
     if (userInfoRes && userInfoRes.data) {
+      console.log(userInfoRes);
       if (userInfoRes.data.code !== 'ok') {
         alert('정보를 가져오는 과정에서 오류가 발생하였습니다.');
       } else {

--- a/src/components/ToolBar/ToolBar.js
+++ b/src/components/ToolBar/ToolBar.js
@@ -31,7 +31,8 @@ function ToolBar() {
     widgets: state.info.widgets,
     modal: state.info.modal,
   }));
-  const user_seq = localStorage.getItem('user_seq');
+  // TODO: 임시
+  const pageUrl = localStorage.getItem('page_url');
 
   const widgetList = [
     { type: 'image', label: '그림', emoji: img, selected: img_selected },
@@ -102,7 +103,7 @@ function ToolBar() {
             type='button'
             css={[commonButtonStyle, cancelButtonWidth]}
             onClick={() => {
-              window.location.assign(`/${user_seq}`);
+              history.push(`/${pageUrl}`);
             }}
           >
             저장하지 않고 나가기
@@ -113,7 +114,7 @@ function ToolBar() {
             onClick={() => {
               const postData = convertForServer(widgets.list);
               history.push({
-                pathname: `/${user_seq}/save`,
+                pathname: `/${pageUrl}/save`,
                 state: { postData },
               });
             }}

--- a/src/components/login/HandleKakaoLogin.js
+++ b/src/components/login/HandleKakaoLogin.js
@@ -23,12 +23,22 @@ function HandleKakaoLogin() {
     request();
   }, []);
 
-  // 기입 필요 유무 확인
   const joinRequired = useMemo(() => {
     console.log(`🚨 res:`);
     console.log(res);
     if (res && res.data) {
-      if (res.data.data && res.data.data.join_required) return true;
+      if (res.data.data && res.data.data.join_required) {
+        return true;
+      }
+    }
+    return false;
+  }, [res]);
+
+  const registered = useMemo(() => {
+    if (res && res.data) {
+      if (res.data.data && res.data.data.registered) {
+        return true;
+      }
     }
     return false;
   }, [res]);
@@ -36,6 +46,11 @@ function HandleKakaoLogin() {
   useEffect(() => {
     if (res && res.data.code === 'error') {
       console.log('!! error: kakao login failed');
+    } else if (res && registered) {
+      alert(
+        `${res.data.data.email}은 다른 방법으로 가입되어있습니다.\n아이디와 비밀번호를 이용해서 로그인해주세요.`
+      );
+      history.push('/login');
     } else if (res && joinRequired) {
       console.log('💎 join');
       history.push({
@@ -49,7 +64,11 @@ function HandleKakaoLogin() {
     } else if (res && !joinRequired) {
       console.log('💎 login');
       setLocalStorage(res.data.data);
-      history.push(`/${localStorage.getItem('user_seq')}`);
+      history.push('/login');
+      // TODO: 고치기;
+      // 헤더에 남의 페이지에서 내 페이지로 가는 버튼도 고쳐야함 => 내 페이지보기, 내 프로필보기, 로그아웃하기 같은거 구현(조그만 모달)
+      // history.push(`/${localStorage.getItem('user_seq')}`);
+      // join에 성공하면 login 시키기
     }
   }, [res, joinRequired]);
 

--- a/src/hooks/useRequestAuth.js
+++ b/src/hooks/useRequestAuth.js
@@ -54,6 +54,12 @@ export function useRequestAuth(props) {
       })
       .catch((err) => {
         console.log(err);
+        setRes({
+          data: {
+            code: 'error',
+            message: '404 not found-server connection failed',
+          },
+        });
       });
   }, [endpoint, method, data]);
 
@@ -69,6 +75,11 @@ export function useRequestAuth(props) {
       }
     }
   }, [resultRes]);
+
+  useEffect(() => {
+    console.log('!!!!!renewStatus');
+    console.log(renewStatus);
+  }, [renewStatus]);
 
   // 토큰을 갱신하는 함수를 만듭니다.
   const renewToken = useCallback(() => {

--- a/src/hooks/useSaveUserInfo.js
+++ b/src/hooks/useSaveUserInfo.js
@@ -1,0 +1,57 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { createReplacementUserAction } from '../redux/slice';
+
+function useSaveUserInfo(...args) {
+  const { userInfo } = useSelector((state) => ({
+    userInfo: state.info.user,
+  }));
+  const dispatch = useDispatch();
+
+  const updateNickname = (nickname) => {
+    dispatch(
+      createReplacementUserAction({
+        ...userInfo,
+        nickname,
+      })
+    );
+  };
+  const updateUserSeq = (user_seq) => {
+    dispatch(
+      createReplacementUserAction({
+        ...userInfo,
+        user_seq,
+      })
+    );
+  };
+  const updateUrl = (url) => {
+    dispatch(
+      createReplacementUserAction({
+        ...userInfo,
+        url,
+      })
+    );
+  };
+  const updateField = (field) => {
+    dispatch(
+      createReplacementUserAction({
+        ...userInfo,
+        field,
+      })
+    );
+  };
+
+  const request = useCallback(() => {
+    if (args.nickname) updateNickname(args.nickname);
+    if (args.url) updateUrl(args.url);
+    if (args.userSeq) updateUserSeq(args.userSeq);
+    if (args.field) updateField(args.field);
+  }, [args]);
+
+  return {
+    res: userInfo,
+    request: request,
+  };
+}
+
+export default useSaveUserInfo;

--- a/src/hooks/useWidgetData.js
+++ b/src/hooks/useWidgetData.js
@@ -1,20 +1,23 @@
-import { useEffect } from 'react';
+// import { useEffect } from 'react';
 import { useRequestAuth } from './useRequestAuth';
 import { getApiEndpoint } from '../utils/util';
 
-export function useWidgetData(targetUserSeq, dest) {
-  const endpoint = `${getApiEndpoint()}/user/${targetUserSeq}/${dest}`;
+export function useWidgetData({ pageUserSeq, dest }) {
+  const endpoint = `${getApiEndpoint()}/user/${pageUserSeq}/widgets/${dest}`;
 
   const { res, request } = useRequestAuth({
     endpoint,
     method: 'get',
   });
 
-  useEffect(() => {
-    request();
-  }, []);
+  // useEffect(() => {
+  //   request();
+  // }, []);
 
-  return { res };
+  return {
+    res,
+    request,
+  };
 }
 
 export default useWidgetData;

--- a/src/hooks/useWidgetData.js
+++ b/src/hooks/useWidgetData.js
@@ -1,19 +1,15 @@
-// import { useEffect } from 'react';
 import { useRequestAuth } from './useRequestAuth';
 import { getApiEndpoint } from '../utils/util';
 
 export function useWidgetData({ pageUserSeq, dest }) {
-  const endpoint = `${getApiEndpoint()}/user/${pageUserSeq}/widgets/${dest}`;
+  const endpoint = `${getApiEndpoint()}/user/${pageUserSeq}/widgets`;
 
   const { res, request } = useRequestAuth({
     endpoint,
     method: 'get',
   });
 
-  // useEffect(() => {
-  //   request();
-  // }, []);
-
+  console.log(dest);
   return {
     res,
     request,

--- a/src/pages/EditModePage.js
+++ b/src/pages/EditModePage.js
@@ -30,7 +30,8 @@ function EditMode() {
       // TODO: code로 match 하는지 받을 수 있음
       console.log(code);
       if (code === 'error' && message === 'no user information') {
-        alert('page user not found');
+        alert('없는 페이지 입니다.');
+        history.push(`${pageUrl}`);
       } else if (code === 'error') {
         alert('db error');
       }

--- a/src/pages/EditModePage.js
+++ b/src/pages/EditModePage.js
@@ -1,22 +1,71 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router';
 import { PageWrapper, ToolBar, EditModeGrid, EditWrapper } from '../components';
 import { useWidgetData } from '../hooks/useWidgetData';
 import PopWidgets from '../components/Widgets/Pop/PopWidgets';
-import { getPageUser } from '../utils/parsing';
-import { isExpiredToken, isInvalidToken, isNotOwner } from '../utils/util';
+import { getPageUrl, getApiEndpoint } from '../utils/util';
 import { convertForRedux } from '../utils/convert';
 import { createReplacementWidgetsAction } from '../redux/slice';
+import { useRequestAuth } from '../hooks/useRequestAuth';
 
 function EditMode() {
   const { modal } = useSelector((state) => ({
     modal: state.info.modal,
   }));
-  const pageUserSeq = getPageUser();
-  const { res } = useWidgetData(pageUserSeq, 'edit');
-  const [storeRequired, setStoreRequired] = useState(false);
-  const dispatch = useDispatch();
 
+  const history = useHistory();
+  const pageUrl = getPageUrl();
+
+  // get page user's info
+  const { res: pageUserRes, request: pageUserRequest } = useRequestAuth({
+    endpoint: `${getApiEndpoint()}/url/${pageUrl}/user`,
+    method: 'get',
+  });
+
+  const pageUserInfo = useMemo(() => {
+    if (pageUserRes && pageUserRes.data) {
+      console.log(pageUserRes);
+      const { code, data, message } = pageUserRes.data;
+      // TODO: code로 match 하는지 받을 수 있음
+      console.log(code);
+      if (code === 'error' && message === 'no user information') {
+        alert('page user not found');
+      } else if (code === 'error') {
+        alert('db error');
+      }
+      console.log(data);
+      if (data) return data;
+    }
+    return null;
+  }, [pageUserRes]);
+
+  useEffect(() => {
+    if (pageUserInfo && !pageUserInfo.user_matched) {
+      history.push(`/${pageUrl}`);
+    }
+  }, [pageUserInfo]);
+
+  const pageUserSeq = useMemo(() => {
+    if (pageUserInfo) {
+      return pageUserInfo.user_seq;
+    }
+    return null;
+  }, [pageUserInfo]);
+
+  useEffect(() => {
+    if (pageUserInfo) {
+      localStorage.setItem('user_seq', pageUserInfo.user_seq);
+      localStorage.setItem('page_url', pageUserInfo.url);
+    }
+  }, [pageUserInfo]);
+
+  const { res: widgetRes, request: widgetRequest } = useWidgetData({
+    pageUserSeq,
+    dest: 'edit',
+  });
+
+  const dispatch = useDispatch();
   const setWidgetState = (widget_data) => {
     const convertedForRedux = convertForRedux(widget_data);
     dispatch(
@@ -28,26 +77,34 @@ function EditMode() {
   };
 
   useEffect(() => {
-    if (storeRequired) {
-      if (res.data.widget_list) {
-        setWidgetState(res.data.widget_list);
-      }
-      setStoreRequired(false);
-    }
-  }, [storeRequired]);
+    console.log('edit page');
+    pageUserRequest();
+  }, []);
 
   useEffect(() => {
-    if (res && res.data) {
-      const { code } = res.data;
-      if (isExpiredToken(code) || isInvalidToken(code) || isNotOwner(code)) {
-        console.log(`=> error code ${res.data.code}`);
-      } else if (code === 'error') {
-        console.log(`=> error code ${res.data.code}`);
-      } else {
-        setStoreRequired(true);
-      }
+    if (pageUserSeq) {
+      console.log(pageUserSeq);
+      widgetRequest();
     }
-  }, [res]);
+  }, [pageUserSeq, widgetRequest]);
+
+  const widgetsData = useMemo(() => {
+    if (widgetRes && widgetRes.data) {
+      const { code: resCode, data } = widgetRes;
+      console.log(resCode);
+      console.log(data);
+      return data;
+    }
+    return null;
+  }, [widgetRes]);
+
+  useEffect(() => {
+    console.log(widgetsData);
+    if (widgetsData) {
+      console.log('set');
+      setWidgetState(widgetsData.widget_list);
+    }
+  }, [widgetsData]);
 
   return (
     <PageWrapper>

--- a/src/pages/JoinPage.js
+++ b/src/pages/JoinPage.js
@@ -120,8 +120,9 @@ function JoinPage() {
     if (res && res.data) {
       console.log(res);
       if (res.data.code === 'ok') {
-        // TODO: login 시키기 -> 토큰 달라고 해야되나?
-        history.push(`/${url.value}`);
+        // TODO: login 시키기는 나중에
+        history.push('/login');
+        // history.push(`/${url.value}`);
       } else {
         alert('전송에 실패했습니다. 다시 시도해주세요.');
       }
@@ -170,7 +171,7 @@ function JoinPage() {
           <button
             type='button'
             css={BackButton}
-            onClick={() => history.push('/')}
+            onClick={() => history.push('/login')}
           >
             첫화면으로 돌아가기
           </button>

--- a/src/pages/JoinPage.js
+++ b/src/pages/JoinPage.js
@@ -120,7 +120,8 @@ function JoinPage() {
     if (res && res.data) {
       console.log(res);
       if (res.data.code === 'ok') {
-        history.push(`/${localStorage.getItem('user_seq')}`);
+        // TODO: login 시키기 -> 토큰 달라고 해야되나?
+        history.push(`/${url.value}`);
       } else {
         alert('전송에 실패했습니다. 다시 시도해주세요.');
       }

--- a/src/pages/NormalModePage.js
+++ b/src/pages/NormalModePage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import {
   NormalWrapper,
@@ -6,26 +6,70 @@ import {
   PageWrapper,
   Header,
 } from '../components';
-import { getPageUser } from '../utils/parsing';
-import { getLoginState, getApiEndpoint } from '../utils/util';
+import { getPageUrl, getApiEndpoint } from '../utils/util';
 import { useWidgetData } from '../hooks/useWidgetData';
-
 import { convertForRedux } from '../utils/convert';
 import { createReplacementWidgetsAction } from '../redux/slice';
 import { useRequestAuth } from '../hooks/useRequestAuth';
 
+// edit페이지로 이동할 수 있는 권한을 체크할 방법이 필요함
+// 1. me로 요청해서 확인한다.
+// 2. 프론트에서 처음에 로그인하면 유저정보를 redux에 넣어놓고 persist를 써서 계속 가지고 있는다.
+// 3. 백엔드에서 토큰으로 처리한다.
+//
 function NormalMode() {
-  const pageUserSeq = getPageUser();
-  const userMatch = getLoginState();
-  const { res } = useWidgetData(pageUserSeq, 'normal');
-  const endpoint = `${getApiEndpoint()}/me`;
+  const pageUrl = getPageUrl();
 
-  const { res: userRes, request } = useRequestAuth({
-    endpoint,
+  // get page user's info
+  const { res: pageUserRes, request: pageUserRequest } = useRequestAuth({
+    endpoint: `${getApiEndpoint()}/url/${pageUrl}/user`,
     method: 'get',
   });
+
+  const pageUserInfo = useMemo(() => {
+    if (pageUserRes && pageUserRes.data) {
+      console.log(pageUserRes);
+      const { code, data, message } = pageUserRes.data;
+      console.log(code);
+      if (code === 'error' && message === 'no user information') {
+        alert('page user not found');
+      } else if (code === 'error') {
+        alert('db error');
+      }
+      console.log(data);
+      if (data) return data;
+    }
+    return null;
+  }, [pageUserRes]);
+
+  const pageUserSeq = useMemo(() => {
+    if (pageUserInfo) {
+      return pageUserInfo.user_seq;
+    }
+    return null;
+  }, [pageUserInfo]);
+
+  const pageUserName = useMemo(() => {
+    if (pageUserInfo) {
+      return pageUserInfo.nickname;
+    }
+    return null;
+  }, [pageUserInfo]);
+
+  // TODO: code 맞추기
+  const userMatch = useMemo(() => {
+    if (pageUserInfo) {
+      return pageUserInfo.user_matched;
+    }
+    return null;
+  }, [pageUserInfo]);
+
+  const { res: widgetRes, request: widgetRequest } = useWidgetData({
+    pageUserSeq,
+    dest: 'normal',
+  });
+
   const dispatch = useDispatch();
-  const [pageUserName, setPageUserName] = useState('');
   const setWidgetState = (widget_data) => {
     const convertedForRedux = convertForRedux(widget_data);
     dispatch(
@@ -37,33 +81,41 @@ function NormalMode() {
   };
 
   useEffect(() => {
-    request();
+    console.log('normal page');
+    pageUserRequest();
   }, []);
 
-  const userInfo = useMemo(() => {
-    console.log('!!!!!!user res');
-    console.log(userRes);
-    if (userRes && userRes.data) return userRes.data.data;
-    return null;
-  }, [userRes]);
+  useEffect(() => {
+    if (pageUserSeq) {
+      console.log(pageUserSeq);
+      widgetRequest();
+    }
+  }, [pageUserSeq, widgetRequest]);
 
-  console.log('userInfo');
-  console.log(userInfo);
+  const widgetsData = useMemo(() => {
+    if (widgetRes && widgetRes.data) {
+      const { code: resCode, data } = widgetRes;
+      console.log(resCode);
+      console.log(data);
+      return data;
+    }
+    return null;
+  }, [widgetRes]);
 
   useEffect(() => {
-    if (res && res.data && res.data.widget_list) {
-      console.log(res);
-      setPageUserName(res.data.user_name);
-      setWidgetState(res.data.widget_list);
+    console.log(widgetsData);
+    if (widgetsData) {
+      console.log('set');
+      setWidgetState(widgetsData.widget_list);
     }
-  }, [res]);
+  }, [widgetsData]);
 
   return (
     <PageWrapper>
       <NormalWrapper>
         <Header
           userMatch={userMatch}
-          pageUserId={pageUserSeq}
+          pageUrl={pageUrl}
           pageUserName={pageUserName}
           pageType='normal'
         />

--- a/src/pages/SavePage.js
+++ b/src/pages/SavePage.js
@@ -20,7 +20,7 @@ function SaveEditPageData() {
     }
   }, [location]);
 
-  const endpoint = `${getApiEndpoint()}/user/${userSeq}/save`;
+  const endpoint = `${getApiEndpoint()}/user/${userSeq}/widgets/save`;
 
   const { res, request } = useRequestAuth({
     endpoint,

--- a/src/pages/SavePage.js
+++ b/src/pages/SavePage.js
@@ -1,39 +1,52 @@
 /** @jsxImportSource @emotion/react */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLocation, useHistory } from 'react-router';
 import LoadingMessageStyle from '../components/LoadingMessageStyle';
 import { getApiEndpoint } from '../utils/util';
 import { useRequestAuth } from '../hooks/useRequestAuth';
 
 function SaveEditPageData() {
-  const user_seq = localStorage.getItem('user_seq');
+  const pageUrl = localStorage.getItem('page_url');
+  const userSeq = localStorage.getItem('user_seq');
   const history = useHistory();
-
   const location = useLocation();
-  if (!location.state) {
-    history.push('/');
-  }
-  const { postData } = location.state;
+  const [postData, setPostData] = useState(null);
 
-  const endpoint = `${getApiEndpoint()}/user/${user_seq}/save`;
+  useEffect(() => {
+    if (location && location.state) {
+      setPostData(location.state.postData);
+    } else {
+      history.push('/');
+    }
+  }, [location]);
 
-  const { request, res, isSuccess } = useRequestAuth({
+  const endpoint = `${getApiEndpoint()}/user/${userSeq}/save`;
+
+  const { res, request } = useRequestAuth({
     endpoint,
     method: 'post',
     data: postData,
   });
 
   useEffect(() => {
-    if (request) {
+    console.log('save');
+    if (postData) {
       request();
     }
-  }, [request]);
+  }, [postData]);
 
   useEffect(() => {
-    if (res && res.data && isSuccess) {
-      history.push(`/${user_seq}`);
+    if (res && res.data) {
+      if (res.data) {
+        // 만료된 토큰의 경우 따로 처리해야함
+        if (res.data.code === 'wrong_token') {
+          history.push(`/login`);
+          alert('로그인을 다시 해주세요.');
+        }
+        history.push(`/${pageUrl}`);
+      }
     }
-  }, [res, isSuccess]);
+  }, [res]);
 
   return <LoadingMessageStyle> 로딩중.. </LoadingMessageStyle>;
 }

--- a/src/pages/SplashPage.js
+++ b/src/pages/SplashPage.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useHistory } from 'react-router';
 import { useRequestAuth } from '../hooks/useRequestAuth';
 import { getApiEndpoint } from '../utils/util';
-
+// TODO: 언마운트 해결
 function SplashPage() {
   const history = useHistory();
 

--- a/src/pages/SplashPage.js
+++ b/src/pages/SplashPage.js
@@ -1,45 +1,31 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router';
-// import { useRequestAuth } from '../hooks/useRequestAuth';
-// import { getApiEndpoint } from '../utils/util';
-// import NormalMode from './NormalModePage';
-// import RenderLoginPage from './RenderLoginPage';
+import { useRequestAuth } from '../hooks/useRequestAuth';
+import { getApiEndpoint } from '../utils/util';
 
 function SplashPage() {
-  // const [login, setLogin] = useState(null);
-  // const endpoint = `${getApiEndpoint()}/me`;
-  const userSeq = localStorage.getItem('user_seq');
-  // const { res } = useRequestAuth(endpoint);
   const history = useHistory();
-  const accessToken = localStorage.getItem('access_token');
-  // const { res } = {
-  //   data: {
-  //     code: 'wrong_token',
-  //   },
-  // };
 
-  // useEffect(() => {
-  //   if (res) {
-  //     setLogin(res.data.code);
-  //   }
-  // }, [res]);
-
-  // useEffect(() => {
-  //   if (login === 'ok') {
-  //     history.push(`/${userSeq}`);
-  //   } else {
-  //     history.push(`/login`);
-  //   }
-  // }, [login]);
+  const { res, request } = useRequestAuth({
+    endpoint: `${getApiEndpoint()}/me`,
+    method: 'get',
+  });
 
   useEffect(() => {
-    if (userSeq && accessToken) {
-      console.log(`userSeq:${userSeq}`);
-      history.push(`/${userSeq}`);
-    } else {
-      history.push(`/login`);
+    console.log('request');
+    request();
+  }, [request]);
+
+  useEffect(() => {
+    console.log(res);
+    if (res && res.data) {
+      if (res.data.code === 'ok') {
+        history.push(`/${res.data.data.url}`);
+      } else {
+        history.push('/login');
+      }
     }
-  }, []);
+  }, [res]);
 
   return <center>onit</center>;
 }

--- a/src/redux/slice.js
+++ b/src/redux/slice.js
@@ -4,8 +4,10 @@ const slice = createSlice({
   name: 'info',
   initialState: {
     user: {
-      name: '',
-      id: -1,
+      nickname: '',
+      user_seq: -1,
+      url: '',
+      field: [],
     },
     modal: {
       imgInputWindow: false,

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -5,5 +5,7 @@ export function moveTo(path) {
 export function logout() {
   localStorage.removeItem('access_token');
   localStorage.removeItem('refresh_token');
+  localStorage.removeItem('user_seq');
+  localStorage.removeItem('page_url');
   window.location.assign('/login');
 }

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1,3 +1,4 @@
+import { useParams } from 'react-router-dom';
 import { getPageUser } from './parsing';
 
 export function getApiEndpoint() {
@@ -30,6 +31,10 @@ export function isNotOwner(code) {
 
 export function isExpiredToken(code) {
   return code === 419 || code === 'expired_token';
+}
+
+export function isWrongToken(code) {
+  return code === 'wrong_token';
 }
 
 export const regexNumber = /\d/gi;
@@ -99,3 +104,8 @@ export const getFieldList = () => [
   { id: 15, label: '캐릭터디자인', name: 'character_design' },
   { id: 16, label: '순수예술', name: 'fine_art' },
 ];
+
+export function getPageUrl() {
+  const { id } = useParams();
+  return id;
+}


### PR DESCRIPTION
- 로컬로 회원가입한 유저가 카카오로 회원가입/로그인 시도시 처리
   - 다른 방식으로 가입된 유저임을 알림
   - `/auth/login/kakao`에 응답(res) 경우의 수 추가
- 위젯 API 관련 코드 수정
   - yekim님 코드 => yoyoo님 코드에 맞게 수정
   - 테스트 완료
- url을 user_seq가 아닌 유저가 회원가입시 등록한 url을 사용하도록 업데이트
   - url을 user 시퀀스에서 user가 등록한 URL로 바꾸기 위해 필요한 '/me' 요청 url 보충 
   -   #108 