### PR TITLE
fix: edit mode page에서 Header에 넣어주는 인자 수정

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -32,7 +32,7 @@ function Header({ userMatch, pageUrl, pageUserName, pageType }) {
 
           <a
             href='#'
-            onClick={() => window.location.assign(`/${user_seq}`)}
+            onClick={() => history.push(`/${user_seq}`)}
             css={marginRight17}
           >
             <img alt='img' src={mypage} css={height26} />
@@ -67,7 +67,7 @@ function Header({ userMatch, pageUrl, pageUserName, pageType }) {
               <button
                 type='button'
                 css={[commonButtonStyle, confirmButtonWidth, marginRight17]}
-                onClick={() => window.location.assign(`/${pageUrl}/edit`)}
+                onClick={() => history.push(`/${pageUrl}/edit`)}
               >
                 페이지 수정
               </button>
@@ -101,7 +101,8 @@ function Header({ userMatch, pageUrl, pageUserName, pageType }) {
             type='button'
             css={[commonButtonStyle, confirmButtonWidth, marginRight12]}
             onClick={() => {
-              window.location.assign(`/${user_seq}`);
+              console.log(pageUrl);
+              history.push(`/${pageUrl}`);
             }}
           >
             저장하지 않고 나가기

--- a/src/pages/EditModePage.js
+++ b/src/pages/EditModePage.js
@@ -99,7 +99,7 @@ function EditMode() {
 
   return (
     <PageWrapper>
-      <Header pageUserId={pageUserSeq} pageType='edit' />
+      <Header userMatch pageUrl={pageUrl} pageType='edit' />
       <EditWrapper>
         {modal.popUpWindow && <PopWidgets />}
         <EditModeGrid />


### PR DESCRIPTION
	- 기존에 toolbar의 역할을 하던 컴포넌트의 삭제로, header를 공유하게 되었으므로, header 컴포넌트에 필요한 자료를 넘겨주도록 edit mode page를 수정
	- 페이지 이동을 window.location.assign로 하지 않고 history.push로 하도록 통일함