### PR TITLE
fixed: 회원가입 url 체크, 로그인 모달 오토포커스 /  feat: 피드백 페이지 팝업 구현

### DIFF
--- a/src/components/FeedbackBox/PlainPopUp.js
+++ b/src/components/FeedbackBox/PlainPopUp.js
@@ -1,0 +1,114 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+
+export function PlainPopUp(props) {
+  const { state, close, textObject } = props;
+
+  return state ? (
+    <div css={[Container]} aria-hidden='true'>
+      <div css={[Overlay]} aria-hidden='true'>
+        <div css={[PopUpBox]}>
+          <div css={[TopText]}>{textObject.topText}</div>
+          <div css={[MiddleText]}>{textObject.middleText}</div>
+          <div css={[BottomText]}>{textObject.bottomText}</div>
+          <button type='button' css={[ConfirmButtom]} onClick={close}>
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  ) : (
+    <></>
+  );
+}
+
+const Container = css`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  z-index: 999999;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Overlay = css`
+  display: flex;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.8);
+  justify-content: center;
+  align-items: center;
+`;
+
+const PopUpBox = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  width: 345px;
+  margin: 15px;
+  padding: 10px;
+  object-fit: contain;
+  border-radius: 20px;
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.16);
+  background-color: white;
+}
+`;
+
+const TopText = css`
+  font-size: 16px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: var(--red-orange, #ff3d00);
+  margin-top: 20px;
+  margin-bottom: 8px;
+`;
+
+const MiddleText = css`
+  font-size: 14px;
+  font-weight: 500;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: var(--red-orange, #ff3d00);
+`;
+
+const BottomText = css`
+  font-size: 12px;
+  font-weight: 500;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: 18px;
+  letter-spacing: normal;
+  color: var(--black, #000000);
+  white-space: pre-line;
+  margin-top: 20px;
+`;
+
+const ConfirmButtom = css`
+  width: 105px;
+  hegith: 28px;
+  font-size: 12px;
+  text-align: center;
+  background-color: var(--red-orange, #ff3d00);
+  color: white;
+  border: none;
+  border-radius: 30px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  padding: 7px 30px 7px 30px;
+  :hover:enabled {
+    opacity: 0.8;
+    cursor: pointer;
+  }
+`;

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef, useLayoutEffect } from 'react';
 import { css } from '@emotion/react';
 import { useHistory } from 'react-router';
 import { getApiEndpoint, setLocalStorage } from '../utils/util';
@@ -11,7 +11,7 @@ import {
 } from '../styles/GlobalStyles';
 import useRequestAuth from '../hooks/useRequestAuth';
 
-function Login() {
+function Login(props) {
   const [emailValue, setEmailValue] = useState('');
   const [passwordValue, setPasswordValue] = useState('');
 
@@ -39,6 +39,13 @@ function Login() {
   };
   const history = useHistory();
 
+  const inputRef = useRef(null);
+  useLayoutEffect(() => {
+    if (inputRef.current !== null) inputRef.current.focus();
+  }, []);
+
+  const { close } = props;
+
   const handleLocalLogin = () => {
     // if (email.state !== 'ok' && password.state !== 'ok') {
     //   alert('아이디와 비밀번호를 확인해주세요.');
@@ -49,6 +56,14 @@ function Login() {
     // } else {
     // }
     request();
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      handleLocalLogin();
+    } else if (event.key === 'Escape') {
+      close();
+    }
   };
 
   useEffect(() => {
@@ -100,6 +115,8 @@ function Login() {
               value={emailValue}
               placeholder='아이디'
               onChange={onEmailChange}
+              onKeyDown={handleKeyDown}
+              ref={inputRef}
             />
           </div>
           <div css={[commonInputBoxStyle]}>
@@ -109,6 +126,7 @@ function Login() {
               value={passwordValue}
               placeholder='비밀번호'
               onChange={onPasswordChange}
+              onKeyDown={handleKeyDown}
             />
           </div>
           <button

--- a/src/hooks/useInput.js
+++ b/src/hooks/useInput.js
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { useEffect, useMemo, useState } from 'react';
-import { isEmail, isURL } from 'validator';
+import { isEmail } from 'validator';
 import { css } from '@emotion/react';
 import {
   COLOR_STYLE,
@@ -8,7 +8,7 @@ import {
   FlexSpaceBetweenCenter,
   SHADOW_STYLE,
 } from '../styles/GlobalStyles';
-import { isPassword, getApiEndpoint } from '../utils/util';
+import { isPassword, getApiEndpoint, isURL } from '../utils/util';
 import useRequestAuth from './useRequestAuth';
 
 function useInput({ inputType, id, type, ...args }) {
@@ -34,9 +34,8 @@ function useInput({ inputType, id, type, ...args }) {
     } else if (inputType === 'nickname') {
       if (value.length > 15) return '15글자 이하로 입력해주세요';
     } else if (inputType === 'url') {
-      const formedUrl = `http://${value}.kr`;
-      if (!isURL(formedUrl))
-        return '언더스코어(_), 콜론(:), 공백문자( ), 슬래시(/)는 사용할 수 없습니다.';
+      // const formedUrl = `http://${value}.kr`;
+      if (!isURL(value)) return '숫자와 영어만 사용하실 수 있습니다!';
       else if (value.length < 4) return '4글자 이상 입력해주세요.';
       else if (value.length > 20) return '20글자 이하로 입력해주세요';
     }

--- a/src/pages/FeedbackPage.js
+++ b/src/pages/FeedbackPage.js
@@ -15,6 +15,7 @@ function FeedbackPage() {
   const [myFeedbacks, setMyFeedbacks] = useState(null);
   const [feedbacks, setFeedbacks] = useState(null);
   const [loading, setLoading] = useState(null);
+  const [needReload, setNeedReload] = useState(false);
   const { loggedIn, myInfo } = useMyInfo();
 
   const endpoint = `${getApiEndpoint()}/feedback`;
@@ -28,10 +29,14 @@ function FeedbackPage() {
     method: 'get',
   });
 
+  const sendReloadSignal = () => {
+    setNeedReload(!needReload);
+  };
+
   useEffect(() => {
     if (loggedIn === false) requestFeedbacks();
     else if (loggedIn === true) requestMyFeedbacks();
-  }, [loggedIn]);
+  }, [loggedIn, needReload]);
   useEffect(() => {
     if (feedbacksRes && feedbacksRes.data) {
       const { code, data, message } = feedbacksRes.data;
@@ -72,7 +77,7 @@ function FeedbackPage() {
       <Header pageType='feedback' />
       <div css={contentsBox}>
         <MainSentence />
-        <FeedbackInputBox />
+        <FeedbackInputBox sendReloadSignal={sendReloadSignal} />
         {loading === 'loggedIn' && (
           <MyfeedbackList myFeedbacks={myFeedbacks} myInfo={myInfo} />
         )}

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -48,8 +48,14 @@ export function isWrongToken(code) {
   return code === 'wrong_token';
 }
 
+export function isURL(formedUrl) {
+  const matched = formedUrl.match(regexAlnum);
+  return matched && matched.length === formedUrl.length;
+}
+
 export const regexNumber = /\d/gi;
 export const regexAlpha = /[a-zA-Z]/gi;
+export const regexAlnum = /[0-9a-zA-Z]/gi;
 export const regexSymbol = /[\^~`$@$+="':;/\\,.<>[\]{}|₩!%*#?&()_-]/gi;
 
 export function hasNumber(word) {


### PR DESCRIPTION
  Fixed
- 기존 validate 라이브러리의 isUrl이 한글을 받는 문제가 있어서 regex로 별도 isUrl을 만들어 대체했습니다.
- 로그인 모달이 떴을 때 아이디 필드를 한 번더 클릭해줘야하는 불편함이 있어서 오토 포커스 적용했습니다
- 로그인 모달 아이디, 비밀번호 필드에서 엔터로 로그인할 수 있게 적용되었습니다.

 Feat
-  피드백 페이지 alert(로그인 필요, 10자 미만, 전송 성공) 3종 팝업 모달로 대체되었습니다.
- 전송 성공시 페이지 전체 reload -> 피드백 컴포넌트만 re-render로 변경되었습니다.