### PR TITLE
fixed: 피드백 무한 리로드 수정

### DIFF
--- a/src/components/FeedbackBox/FeedbackInputBox.js
+++ b/src/components/FeedbackBox/FeedbackInputBox.js
@@ -9,7 +9,7 @@ import { PlainPopUp } from './PlainPopUp';
 
 const inputColor = '#fff';
 
-function FeedbackInputBox(props) {
+function FeedbackInputBox({ sendReloadSignal }) {
   const [inputmessage, setInputmessage] = useState('');
   const [showPopUp, setShowPopUp] = useState(false);
   const [popUpText, setPopUpText] = useState({
@@ -30,8 +30,6 @@ function FeedbackInputBox(props) {
       content: inputmessage,
     },
   });
-
-  const { sendReloadSignal } = props;
 
   function closePopUp() {
     setShowPopUp(false);

--- a/src/pages/FeedbackPage.js
+++ b/src/pages/FeedbackPage.js
@@ -31,7 +31,7 @@ function FeedbackPage() {
 
   const sendReloadSignal = useCallback(() => {
     setNeedReload(!needReload);
-  }, [needReload]);
+  }, []);
 
   useEffect(() => {
     if (loggedIn === false) requestFeedbacks();


### PR DESCRIPTION
피드백 전송 시 sendReloadSignal를 호출하여 리로드하는데, 그 때 needReload를 바꾸는 useEffect 의존성에 needReload를 걸어두어 계속 리로드 되는 것을 확인하여, 의존성에서 제거해주었습니다.