### PR TITLE
fixed: 이메일 인증 안되던 버그 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,11 @@ function App() {
         <Route exact path='/join' component={JoinPage} />
         <Route exact path='/feedback' component={FeedbackPage} />
         <Route exact path='/callback/kakao' component={HandleKakaoLogin} />
+        <Route
+          exact
+          path='/certificate/:email/:code'
+          component={EmailCertPage}
+        />
         <Route exact path='/:personalUrl/' component={MyPage} />
         {/* 나중에 pageUrl로 바껴야 됨 */}
         <Route
@@ -40,11 +45,6 @@ function App() {
           exact
           path='/:personalUrl/:publishingUrl/:pageUrl'
           component={PublishingSplitPage}
-        />
-        <Route
-          exact
-          path='/certificate/:email/:code'
-          component={EmailCertPage}
         />
         <Route path='/'>
           <div> 존재하지 않는 페이지입니다. </div>


### PR DESCRIPTION
이메일 인증 시 뜨는 '불러오는 중입니다'라는 문구는 싱글 페이지에서 렌더링을 기다릴 때 뜨는 문구였습니당.
라우터 순서에 문제가 있다고 생각하여 순서를 바꿔주니 해결되었습니다.

앞으로도
라우터 경로가 정해진 경로를 우선순위로 배치해야 할 것 같습니다.
그리고 라우터 경로에 들어간 문자는 페이지url 이름으로 쓰지 못하게 걸러주어야 할 것 같습니다.