### PR TITLE
[개선] 편의성 수정

### DIFF
--- a/src/components/GridLayout/EditModeGrid.js
+++ b/src/components/GridLayout/EditModeGrid.js
@@ -6,7 +6,10 @@ import { useFloating, shift, offset } from '@floating-ui/react-dom';
 import { flip } from '@floating-ui/core';
 import GridLayout from './GridLayout';
 import MouseGridLayout from './MouseGridLayout';
-import { createReplacementWidgetsAction } from '../../redux/slice';
+import {
+  createReplacementWidgetsAction,
+  createReplacementModalAction,
+} from '../../redux/slice';
 import { WidgetElement } from '../Widgets/WidgetElement';
 import {
   GRID_COLS,
@@ -20,6 +23,7 @@ import {
   ACTION_EDIT,
   TYPE_MOUSE,
   TYPE_NONEDISPLAY,
+  TYPE_NEW,
 } from '../../utils/constantValue';
 import useWindowSize from './useWindowSize';
 import ToolBar from '../ToolBar/ToolBar';
@@ -54,6 +58,7 @@ function EditModeGrid() {
   // toolBar 선택위한 위젯
   const [selectedWidget, setSelectedWidget] = useState(null);
   const [gridHeight, setGridHeight] = useState(1);
+  const [newWidgetFlag, setNewWidgetFlag] = useState(false);
   const {
     x,
     y,
@@ -67,7 +72,7 @@ function EditModeGrid() {
   });
 
   const dispatch = useDispatch();
-  const { widgets } = useSelector((state) => ({
+  const { widgets, modal } = useSelector((state) => ({
     widgets: state.info.widgets,
     modal: state.info.modal,
   }));
@@ -79,6 +84,31 @@ function EditModeGrid() {
       window.removeEventListener('scroll', () => handleScrollWidth()); // clean up
     };
   }, []);
+
+  useEffect(() => {
+    if (newWidgetFlag && widgets) {
+      const target = widgets.list[widgets.count];
+      if (
+        target &&
+        target.widget_action === 'C' &&
+        target.widget_type === TYPE_NEW
+      ) {
+        setSelectedWidget(target.i);
+        openEditWindow(target.i);
+        setNewWidgetFlag(false);
+      }
+    }
+  }, [widgets, newWidgetFlag]);
+
+  const openEditWindow = (id) => {
+    dispatch(
+      createReplacementModalAction({
+        ...modal,
+        imgInputWindow: true,
+        targetWidgetId: id,
+      })
+    );
+  };
 
   const handleScrollWidth = () => {
     if (window.scrollY > 100 && window.scrollY < 10000) {
@@ -102,6 +132,7 @@ function EditModeGrid() {
     }
     if (isWidgetOverlap === false) {
       addEmptyWidget(mouseOverWidget);
+      setNewWidgetFlag(true);
     }
   };
 

--- a/src/components/MyPage/AddPagePopUp.js
+++ b/src/components/MyPage/AddPagePopUp.js
@@ -1,11 +1,11 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import React, { useState, useCallback, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router';
 import { useRequest } from '../../hooks/useRequest';
 import useRequestAuth from '../../hooks/useRequestAuth';
 import { getApiEndpoint } from '../../utils/util';
-import { createReplacementSinglePagesAction } from '../../redux/slice';
+import { useGetPersonalUrl } from '../../hooks/useParamsUrl';
 import { commonBtn, getAbsoluteBtn } from '../../styles/GlobalStyles';
 import { closeSet } from '../../asset';
 import { PlainPopUp } from '../FeedbackBox/PlainPopUp';
@@ -52,12 +52,8 @@ function AddPagePopUp({ userSeq, setPopUp }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [thumbnail]);
 
-  const dispatch = useDispatch();
-  // eslint-disable-next-line no-unused-vars
-  const { res: singlePagesData, request: requestSinglePagesData } = useRequest({
-    endpoint: `${getApiEndpoint()}/user/page/singles/${userSeq}`,
-    method: 'get',
-  });
+  const history = useHistory();
+  const personalUrl = useGetPersonalUrl();
 
   const { res: urlOverlapRes, request: requestUrlOverlap } = useRequest({
     endpoint: `${getApiEndpoint()}/user/page/overlap/${inputs.url}/${userSeq}`,
@@ -93,7 +89,7 @@ function AddPagePopUp({ userSeq, setPopUp }) {
       setPopUpText({
         topText: '데이터 전송 중',
         middleText: '열심히 데이터를 보내고 있습니다!',
-        bottomText: '조금만 더 기다려주시면 멋진 페이지를 보여드릴게요!',
+        bottomText: '조금만 더 기다려주시면 멋진 페이퍼를 보여드릴게요!',
       });
       setSendingPopUp(true);
       request();
@@ -110,18 +106,18 @@ function AddPagePopUp({ userSeq, setPopUp }) {
       setHasButton(true);
       setPopUpText({
         topText: '문제가 발생했어요!',
-        middleText: '가지고 계신 페이지에 이미 해당 주소가 있어요.',
+        middleText: '가지고 계신 페이퍼에 이미 해당 주소가 있어요.',
         bottomText:
-          '같은 주소에는 하나의 페이지만 있을 수 있습니다.\n아쉽지만 다른 주소로 설정해주세요!',
+          '같은 주소에는 하나의 페이퍼만 있을 수 있습니다.\n아쉽지만 다른 주소로 설정해주세요!',
       });
       setSendingPopUp(true);
     } else if (errorRes === URL_FORMAT_ERROR) {
       setHasButton(true);
       setPopUpText({
         topText: '문제가 발생했어요!',
-        middleText: '설정하신 페이지 주소가 규칙에 맞지 않아요.',
+        middleText: '설정하신 페이퍼 주소가 규칙에 맞지 않아요.',
         bottomText:
-          '페이지 주소는 4글자 이상 20글자 이하\n영어와 숫자만 사용가능해요!',
+          '페이퍼 주소는 4글자 이상 20글자 이하\n영어와 숫자만 사용가능해요!',
       });
       setSendingPopUp(true);
     }
@@ -141,10 +137,10 @@ function AddPagePopUp({ userSeq, setPopUp }) {
     }
   }, [urlOverlapRes]);
 
-  function closeSendingPopUp() {
+  const closeSendingPopUp = useCallback(() => {
     setErrorRes(null);
     setSendingPopUp(false);
-  }
+  }, []);
 
   const checkFormInputs = (e) => {
     if (inputs.url === '' || inputs.title === '') {
@@ -162,28 +158,23 @@ function AddPagePopUp({ userSeq, setPopUp }) {
 
   useEffect(() => {
     if (res && res.data.code === 'ok') {
-      requestSinglePagesData();
+      console.log(res);
+      closeSendingPopUp();
+      history.push(`/${personalUrl}/${inputs.url}/edit`);
     }
-  }, [res, requestSinglePagesData]);
-
-  useEffect(() => {
-    if (singlePagesData && singlePagesData.data) {
-      dispatch(createReplacementSinglePagesAction(singlePagesData.data));
-      setPopUp(false);
-    }
-  }, [singlePagesData, dispatch, setPopUp]);
+  }, [res]);
 
   const { btn, img } = getAbsoluteBtn(25, 42, 25);
   const firstInput = {
-    head: '페이지 제목',
+    head: '페이퍼 제목',
     placeholder: '제목을 입력해주세요!',
   };
-  const secondInput = { head: '페이지 주소', placeholder: '' };
+  const secondInput = { head: '페이퍼 주소', placeholder: '' };
 
   return (
     <div css={[backGroundPopStyle]}>
       <div css={[pagePopUpBoxStyle]}>
-        <div css={[pagePopUpBoxTitle]}>페이지 추가</div>
+        <div css={[pagePopUpBoxTitle]}>페이퍼 추가</div>
         <form css={[formWidth]}>
           <button
             type='button'

--- a/src/components/MyPage/BindingPopUp.jsx
+++ b/src/components/MyPage/BindingPopUp.jsx
@@ -65,7 +65,7 @@ function BindingPopUp({ userSeq, setPopUp }) {
   return (
     <div css={[backGroundPopStyle]}>
       <div css={[pagePopUpBoxStyle]}>
-        <div css={[pagePopUpBoxTitle, BlockDrag]}>페이지 합치기</div>
+        <div css={[pagePopUpBoxTitle, BlockDrag]}>페이퍼 합치기</div>
         <form css={[formWidth]}>
           <button
             type='button'
@@ -95,7 +95,7 @@ function BindingPopUp({ userSeq, setPopUp }) {
             </div>
             <div>
               <div css={[VerticalLayout]}>
-                <div css={[pagePopUpBoxContents, BlockDrag]}>페이지 선택</div>
+                <div css={[pagePopUpBoxContents, BlockDrag]}>페이퍼 선택</div>
                 <BindingSelectSinglePages
                   selectedPages={selectedPages}
                   setSelectedPages={setSelectedPages}

--- a/src/components/MyPage/BindingSelectSinglePages.jsx
+++ b/src/components/MyPage/BindingSelectSinglePages.jsx
@@ -47,7 +47,7 @@ const BindingSelectSinglePages = ({ selectedPages, setSelectedPages }) => {
     </div>
   ) : (
     <div css={[siteViewBZone, noneScrollBar]}>
-      <div css={[noneSinglePageMsg]}>합칠 수 있는 페이지가 없어요!</div>
+      <div css={[noneSinglePageMsg]}>합칠 수 있는 페이퍼가 없어요!</div>
     </div>
   );
 };

--- a/src/components/MyPage/ModifyPageInfoPopUp.jsx
+++ b/src/components/MyPage/ModifyPageInfoPopUp.jsx
@@ -99,14 +99,14 @@ function ModifyPageInfoPopUp({ pageType, userSeq, data, setPopUp }) {
 
   const { btn, img } = getAbsoluteBtn(25, 42, 25);
   const firstInput = {
-    head: '페이지 제목',
+    head: '페이퍼 제목',
     placeholder: data.title,
   };
 
   return (
     <div css={[backGroundPopStyle]}>
       <div css={[pagePopUpBoxStyle]}>
-        <div css={[pagePopUpBoxTitle]}>페이지 수정</div>
+        <div css={[pagePopUpBoxTitle]}>페이퍼 수정</div>
         <form css={[formWidth]}>
           <button
             type='button'

--- a/src/components/MyPage/PageBlock.js
+++ b/src/components/MyPage/PageBlock.js
@@ -81,9 +81,9 @@ function PageBlock({ userMatched, data, userUrl, pageType }) {
   };
 
   const deletePopUpText = {
-    topText: '페이지 삭제',
-    middleText: '확인 버튼을 누르면 페이지가 삭제됩니다!',
-    bottomText: '삭제하신 페이지는 복구가 어려우니 한 번 더 확인해주세요!',
+    topText: '페이퍼 삭제',
+    middleText: '확인 버튼을 누르면 페이퍼가 삭제됩니다!',
+    bottomText: '삭제하신 페이퍼는 복구가 어려우니 한 번 더 확인해주세요!',
   };
 
   const diameter = 44;
@@ -172,7 +172,7 @@ function PageBlock({ userMatched, data, userUrl, pageType }) {
                     white-space: nowrap;
                   `}
                 >
-                  수정
+                  편집
                 </div>
               </Link>
             )}

--- a/src/components/Widgets/Text/Text.css
+++ b/src/components/Widgets/Text/Text.css
@@ -22,5 +22,10 @@
 }
 
 .ck.ck-editor__editable_inline {
+  overflow: hidden !important;
   overflow-wrap: break-word;
+}
+
+.ck.ck-read-only .ck-placeholder:before {
+  display: block !important;
 }

--- a/src/components/Widgets/Text/Text.js
+++ b/src/components/Widgets/Text/Text.js
@@ -26,20 +26,21 @@ function TextEditor(props) {
 
   useEffect(() => {
     const editor = editorRef.current;
-    const newList = JSON.parse(JSON.stringify(widgets.list));
-    const found = newList.find((widget) => widget.i === props.widgetId);
-    let isPinned = false;
-    if (found?.static !== undefined) {
-      isPinned = found.static;
-    }
+    // const newList = JSON.parse(JSON.stringify(widgets.list));
+    // const found = newList.find((widget) => widget.i === props.widgetId);
+    // let isPinned = false;
+    // if (found?.static !== undefined) {
+    //   isPinned = found.static;
+    // }
     if (editor.editor) {
-      if (isPinned === true) {
+      if (props.isStatic === true) {
         editor.editor.disableReadOnlyMode(props.widgetId);
-      } else if (isPinned === false) {
+        editor.editor.focus();
+      } else if (props.isStatic === false) {
         editor.editor.enableReadOnlyMode(props.widgetId);
       }
     }
-  }, [widgets.list, props.widgetId]);
+  }, [props.isStatic]);
 
   // const handleClick = useCallback(() => {
   //   const editor = editorRef.current;
@@ -103,7 +104,7 @@ function TextEditor(props) {
                 isFloating: true,
                 shouldNotGroupWhenFull: true,
               },
-              placeholder: '텍스트를 입력하세요!',
+              placeholder: '설정 버튼으로 입력/이동 모드를 전환',
               heading: {
                 options: [
                   {

--- a/src/components/Widgets/Text/TextBox.js
+++ b/src/components/Widgets/Text/TextBox.js
@@ -13,7 +13,7 @@ function TextBox({ element, mode }) {
   return mode === 'normal' ? (
     <Viewer content={element.widget_data.thumbnail} />
   ) : (
-    <TextEditor widgetId={element.i} />
+    <TextEditor widgetId={element.i} isStatic={element.static} />
   );
 }
 

--- a/src/components/Widgets/WidgetElement.js
+++ b/src/components/Widgets/WidgetElement.js
@@ -199,6 +199,7 @@ const widgetFrame = css`
   width: 100%;
   height: 100%;
   border-diameter: ${WIDGET_COMMON_RADIUS};
+  overflow: hidden;
 `;
 
 /*

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -176,12 +176,22 @@ export function useIsPathExist() {
       if (publishPageRes.data.code !== 'ok') setErrorCode('page_error');
       else if (publishPageRes.data.data.isMultiPage === true)
         setIsMultiPage(true);
+      else if (publishPageRes.data.data.isMultiPage === false && pageUrl)
+        setErrorCode('page_error');
       else setErrorCode('ok');
     }
   }, [publishPageRes]);
 
   useEffect(() => {
-    if (isMultiPage && pageUrl) requestSinglePageInfo();
+    if (isMultiPage && pageUrl) {
+      if (
+        publishPageRes.data.data.singlePages.find(
+          (list) => list.singlePageUrl === pageUrl
+        )
+      )
+        requestSinglePageInfo();
+      else setErrorCode('page_error');
+    }
   }, [isMultiPage, pageUrl]);
 
   useEffect(() => {


### PR DESCRIPTION
1. 개인 페이지 단어 수정
- 수정 -> 편집
- 페이지 -> 페이퍼

2. 페이퍼 생성 시 바로 edit 페이지로
- history.push

3. 위젯 생성 시 툴바 표시
- useState로 신규 빈 위젯 생성 체크(newWidgetFlag)
- widgets과 newWidgetFlag를 의존성 배열로한 useEffect에서 현재 widgets 중 제일 최근에 생긴 위젯 action이 C고 타입이 NEW이면 툴바 띄우고 newWidgetFlag 꺼주기
 
4. 텍스트 위젯
- 읽기 전용 모드에서 placeholder 표시(라이브러리에서는 display:none 으로 정해져있어서 !important를 통해 덮어씌움)
- overflow: hidden (위와 동일)
- 쓰기 모드 전환 시 포커스(기존 코드는 동작 시 마다 포커스가 변경되어서 부모 컴포넌트로 부터 static 값 받아서 작동)