### PR TITLE
[개선] 툴바 위치, 페이지 수정 팝업 문구 수정, 페이지 생성 URL 규칙 수정

### DIFF
--- a/src/components/GridLayout/EditModeGrid.js
+++ b/src/components/GridLayout/EditModeGrid.js
@@ -67,8 +67,8 @@ function EditModeGrid() {
     strategy,
     update: updateFloatingUi,
   } = useFloating({
-    placement: 'top-start',
-    middleware: [shift(), flip(), offset(25)],
+    placement: 'top-end',
+    middleware: [shift(), flip(), offset(5)],
   });
 
   const dispatch = useDispatch();

--- a/src/components/MyPage/BindingInputBox.jsx
+++ b/src/components/MyPage/BindingInputBox.jsx
@@ -21,7 +21,7 @@ const BindingInputBox = (props) => {
     if (url === '' || !isUrl) return '';
     if (!isURL(url)) return '숫자와 영어만 사용하실 수 있습니다!';
     else if (url.length < 4) return '4글자 이상 입력해주세요.';
-    else if (url.length > 20) return '16글자 이하로 입력해주세요';
+    else if (url.length > 16) return '16글자 이하로 입력해주세요';
     else {
       // 중복 체크 API 들어갈 부분
       return 'ok';

--- a/src/components/MyPage/ModifyPageInfoPopUp.jsx
+++ b/src/components/MyPage/ModifyPageInfoPopUp.jsx
@@ -21,6 +21,7 @@ function ModifyPageInfoPopUp({ pageType, userSeq, data, setPopUp }) {
   });
   const [thumbnail, setThumbnail] = useState(data.thumbnail);
   const { title } = inputs;
+  const pageTypeText = pageType === 'single' ? '페이퍼 ' : '페이지 ';
 
   const onChange = useCallback(
     (e) => {
@@ -99,14 +100,14 @@ function ModifyPageInfoPopUp({ pageType, userSeq, data, setPopUp }) {
 
   const { btn, img } = getAbsoluteBtn(25, 42, 25);
   const firstInput = {
-    head: '페이퍼 제목',
+    head: `${pageTypeText}제목`,
     placeholder: data.title,
   };
 
   return (
     <div css={[backGroundPopStyle]}>
       <div css={[pagePopUpBoxStyle]}>
-        <div css={[pagePopUpBoxTitle]}>페이퍼 수정</div>
+        <div css={[pagePopUpBoxTitle]}>{pageTypeText}수정</div>
         <form css={[formWidth]}>
           <button
             type='button'


### PR DESCRIPTION
1. 툴바 위치
- 상단 끝쪽으로 이동시켜서 설정 버튼에 가깝게 배치했습니다. 
- 그리드와 간격이 넓어 사이에 있는 그리드에 hover가 되는 현상이 있어서 오프셋을 줄였습니다.
2. 페이지 수정 팝업 문구 수정
- 멀티페이지 : 페이지
- 싱글페이지 : 페이퍼
3. 페이지 생성 URL 규칙
- 문자 자체의 크기에 따라 20글자 전에 필드를 넘어가는 경우가 있어 16글자 이하로 조정했습니다.